### PR TITLE
kitakami-common: Remove android_device_qcom_common dependency

### DIFF
--- a/lineage.dependencies
+++ b/lineage.dependencies
@@ -4,10 +4,6 @@
     "target_path": "device/sony/common"
   },
   {
-    "repository": "android_device_qcom_common",
-    "target_path": "device/qcom/common"
-  },
-  {
     "repository": "android_hardware_sony_timekeep",
     "target_path": "hardware/sony/timekeep"
   },


### PR DESCRIPTION
This dependency was last used in 15.1 and is no longer required.