### PR TITLE
libril: Fix network operator search

### DIFF
--- a/libril/ril_service.cpp
+++ b/libril/ril_service.cpp
@@ -1352,7 +1352,7 @@ Return<void> RadioImpl::setNetworkSelectionModeAutomatic(int32_t serial) {
 #if VDBG
     RLOGD("setNetworkSelectionModeAutomatic: serial %d", serial);
 #endif
-    dispatchVoid(serial, mSlotId, RIL_REQUEST_SET_NETWORK_SELECTION_AUTOMATIC);
+    dispatchStrings(serial, mSlotId, RIL_REQUEST_SET_NETWORK_SELECTION_AUTOMATIC, 0);
     return Void();
 }
 
@@ -1362,13 +1362,13 @@ Return<void> RadioImpl::setNetworkSelectionModeManual(int32_t serial,
     RLOGD("setNetworkSelectionModeManual: serial %d", serial);
 #endif
 #ifndef OLD_MNC_FORMAT
-    dispatchString(serial, mSlotId, RIL_REQUEST_SET_NETWORK_SELECTION_MANUAL,
-            operatorNumeric.c_str());
+    dispatchStrings(serial, mSlotId, RIL_REQUEST_SET_NETWORK_SELECTION_MANUAL, true,
+            1, operatorNumeric.c_str());
 #else
     std::string opNum = operatorNumeric;
     opNum.append("+");
-    dispatchString(serial, mSlotId, RIL_REQUEST_SET_NETWORK_SELECTION_MANUAL,
-            opNum.c_str());
+    dispatchStrings(serial, mSlotId, RIL_REQUEST_SET_NETWORK_SELECTION_MANUAL, true,
+            1, opNum.c_str());
 #endif
     return Void();
 }

--- a/libril/ril_service.cpp
+++ b/libril/ril_service.cpp
@@ -614,25 +614,11 @@ bool dispatchStrings(int serial, int slotId, int request, bool allowEmpty, int c
         for (int i = 0 ; i < countStrings ; i++) {
             memsetAndFreeStrings(1, pStrings[i]);
         }
-bool dispatchStrings(int serial, int slotId, int request, bool allowEmpty, int countStrings, ...)
+
 #ifdef MEMSET_FREED
         memset(pStrings, 0, countStrings * sizeof(char *));
 #endif
         free(pStrings);
-    }
-
-    /**
-      * Sony 8960 RIL stack compatibility
-      * Qualcomm's RIL doesn't seem to issue any callbacks for opcode 47
-      * This may be a bug on how we call rild or simply some proprietary 'feature'
-      * ..and we don't care: We simply send a SUCCESS message back to the caller to
-      * indicate that we received the command & unblock the UI.
-      * The user will still see if the registration was OK by using the
-      * normal signal meter
-      */
-    if (request == RIL_REQUEST_SET_NETWORK_SELECTION_MANUAL) {
-        RLOGE("Sending fake success event for request %s", requestToString(request));
-        RIL_onRequestComplete(pRI, RIL_E_SUCCESS, NULL, 0);
     }
     return true;
 }

--- a/libril/ril_service.cpp
+++ b/libril/ril_service.cpp
@@ -620,6 +620,20 @@ bool dispatchStrings(int serial, int slotId, int request, bool allowEmpty, int c
 #endif
         free(pStrings);
     }
+
+    /**
+      * Sony 8960 RIL stack compatibility
+      * Qualcomm's RIL doesn't seem to issue any callbacks for opcode 47
+      * This may be a bug on how we call rild or simply some proprietary 'feature'
+      * ..and we don't care: We simply send a SUCCESS message back to the caller to
+      * indicate that we received the command & unblock the UI.
+      * The user will still see if the registration was OK by using the
+      * normal signal meter
+      */
+    if (request == RIL_REQUEST_SET_NETWORK_SELECTION_MANUAL) {
+        RLOGE("Sending fake success event for request %s", requestToString(request));
+        RIL_onRequestComplete(pRI, RIL_E_SUCCESS, NULL, 0);
+    }
     return true;
 }
 

--- a/libril/ril_service.cpp
+++ b/libril/ril_service.cpp
@@ -614,11 +614,25 @@ bool dispatchStrings(int serial, int slotId, int request, bool allowEmpty, int c
         for (int i = 0 ; i < countStrings ; i++) {
             memsetAndFreeStrings(1, pStrings[i]);
         }
-
+bool dispatchStrings(int serial, int slotId, int request, bool allowEmpty, int countStrings, ...)
 #ifdef MEMSET_FREED
         memset(pStrings, 0, countStrings * sizeof(char *));
 #endif
         free(pStrings);
+    }
+
+    /**
+      * Sony 8960 RIL stack compatibility
+      * Qualcomm's RIL doesn't seem to issue any callbacks for opcode 47
+      * This may be a bug on how we call rild or simply some proprietary 'feature'
+      * ..and we don't care: We simply send a SUCCESS message back to the caller to
+      * indicate that we received the command & unblock the UI.
+      * The user will still see if the registration was OK by using the
+      * normal signal meter
+      */
+    if (request == RIL_REQUEST_SET_NETWORK_SELECTION_MANUAL) {
+        RLOGE("Sending fake success event for request %s", requestToString(request));
+        RIL_onRequestComplete(pRI, RIL_E_SUCCESS, NULL, 0);
     }
     return true;
 }


### PR DESCRIPTION
* For search, the number of strings returned for
  RIL_REQUEST_QUERY_AVAILABLE_NETWORKS should be defined in the system
  prop ro.ril.telephony.mqanelements

Change-Id: Ie5bb8ba80c5ac93b7502da3b1bb3d2b4404ecd5e